### PR TITLE
"Downgrade" to node.js v12.x

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -37,7 +37,7 @@ if (process.env.RUN_NETWORK_TESTS !== 'true') {
     }
 
     for (const sparsePackage of await getSparsePackages()) {
-      await fs.promises.rm(sparsePackage)
+      await fs.promises.unlink(sparsePackage)
     }
 
     expect(

--- a/package-lock.json
+++ b/package-lock.json
@@ -2175,9 +2175,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.10.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.3.tgz",
-      "integrity": "sha512-ho3Ruq+fFnBrZhUYI46n/bV2GjwzSkwuT4dTf0GkuNFmnb8nq4ny2z9JEVemFi6bdEJanHLlYfy9c6FN9B9McQ=="
+      "version": "12.20.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.29.tgz",
+      "integrity": "sha512-dU2ypz+gO5va1OBvs0iT3BNHG5SgTqRvq8r+kU3e/LAseKapUJ8zTUE9Ve9fTpi27tN/7ahOAhCJwQWsffvsyw=="
     },
     "@types/node-fetch": {
       "version": "2.5.10",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.0.2",
-    "@types/node": "^16.10.3",
+    "@types/node": "^12.12.6 <13.0.0",
     "@types/unzipper": "^0.10.4",
     "@typescript-eslint/parser": "^4.33.0",
     "@vercel/ncc": "^0.31.1",


### PR DESCRIPTION
GitHub Actions run on node.js v12.x, therefore we cannot use any newer features. This lead to an error in a recent upgrade when trying to unpack and download the full SDK:

```
TypeError: fs_1.default.promises.rm is not a function
```

By pinning @types/node to a version compatible with node.js v12.x we will avoid this issue in the future.