### PR TITLE
ci: Automagically repackage when Dependabot updates a dependency

### DIFF
--- a/.github/workflows/npm-run-package.yml
+++ b/.github/workflows/npm-run-package.yml
@@ -1,0 +1,45 @@
+name: 'npm run package'
+# Main use case: repackage when Dependabot updates a dependency
+on:
+  push:
+    branches:
+      - 'dependabot/**'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Process this branch'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  npm-run-package-and-push: # make sure build/ci work properly
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.branch }}
+      - run: npm ci
+      - run: npm run build
+      - run: npm run lint
+      - run: npm run format && git diff-files
+      - run: npm run test
+      - run: npm run package
+      - name: check if commit & push is needed
+        id: check
+        run: |
+          git add -u -- dist/ &&
+          git diff-index --cached --exit-code HEAD -- ||
+          echo "::set-output name=need-to-commit::yes"
+      - name: commit & push
+        if: steps.check.outputs.need-to-commit == 'yes'
+        run: |
+          git config user.name "${{github.actor}}" &&
+          git config user.email "${{github.actor}}@users.noreply.github.com" &&
+          git commit -m 'npm run build && npm run package' -- dist/ &&
+          git update-index --refresh &&
+          git diff-files --exit-code &&
+          git diff-index --cached --exit-code HEAD -- &&
+          git push


### PR DESCRIPTION
Every once in a while, a non-dev dependency is updated by Dependabot. This obviously changes what is then packaged into `dist/`, and the PR build fails.

Instead of manually checking out the respective branch, repackaging, committing and pushing, let's have a workflow that automates all of this quite boring and repetitive work.