### PR TITLE
Upgrade to Node v16.x

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,5 +33,5 @@ inputs:
     description: 'Filter results by the reason for the build; Defaults to "all"'
     default: 'all'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@types/jest": "^27.4.1",
-        "@types/node": "^12.12.6 <18.0.0",
+        "@types/node": "^16.11.7 <18.0.0",
         "@types/unzipper": "^0.10.5",
         "@typescript-eslint/parser": "^5.20.0",
         "@vercel/ncc": "^0.33.4",
@@ -1925,9 +1925,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "12.20.48",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.48.tgz",
-      "integrity": "sha512-4kxzqkrpwYtn6okJUcb2lfUu9ilnb3yhUOH6qX3nug8D2DupZ2drIkff2yJzYcNJVl3begnlcaBJ7tqiTTzjnQ=="
+      "version": "16.11.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.27.tgz",
+      "integrity": "sha512-C1pD3kgLoZ56Uuy5lhfOxie4aZlA3UMGLX9rXteq4WitEZH6Rl80mwactt9QG0w0gLFlN/kLBTFnGXtDVWvWQw=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.5.12",
@@ -10637,9 +10637,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.20.48",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.48.tgz",
-      "integrity": "sha512-4kxzqkrpwYtn6okJUcb2lfUu9ilnb3yhUOH6qX3nug8D2DupZ2drIkff2yJzYcNJVl3begnlcaBJ7tqiTTzjnQ=="
+      "version": "16.11.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.27.tgz",
+      "integrity": "sha512-C1pD3kgLoZ56Uuy5lhfOxie4aZlA3UMGLX9rXteq4WitEZH6Rl80mwactt9QG0w0gLFlN/kLBTFnGXtDVWvWQw=="
     },
     "@types/node-fetch": {
       "version": "2.5.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7452,9 +7452,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -14681,9 +14681,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "minimist-options": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",
-    "@types/node": "^12.12.6 <18.0.0",
+    "@types/node": "^16.11.7 <18.0.0",
     "@types/unzipper": "^0.10.5",
     "@typescript-eslint/parser": "^5.20.0",
     "@vercel/ncc": "^0.33.4",


### PR DESCRIPTION
GitHub Actions now support running on Node v16 instead of v12. Let's do that, too.